### PR TITLE
Fix getauxval crash

### DIFF
--- a/src/2.16/getauxval.c
+++ b/src/2.16/getauxval.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 #include <dlfcn.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -13,73 +14,125 @@
 
 #include "common.h"
 
-/** types **/
+/** function prototypes **/
+static unsigned long _getauxval_init_wrapper(unsigned long type);
 
+/** types **/
 typedef unsigned long (*pfn_getauxval)(unsigned long type);
 
 /** globals **/
-static ElfW(auxv_t) *g_auxv = NULL;;
-static pfn_getauxval getauxval_fn = NULL;
+static ElfW(auxv_t) *g_auxv = NULL;
+static pfn_getauxval getauxval_fn = _getauxval_init_wrapper;
 
-static unsigned long _getauxval(unsigned long type){
-	ElfW(auxv_t) *a;
-	for(a = g_auxv; a->a_type != 0 && a->a_type != type; ++a);
-	return (a->a_type == 0) ? 0 : a->a_un.a_val;
+#ifdef SKIP_GLIBC
+# define DEFAULT_SKIP_GLIBC true
+#else
+# define DEFAULT_SKIP_GLIBC false
+#endif
+static const bool getauxval_default_skip_glibc = DEFAULT_SKIP_GLIBC;
+
+static unsigned long _getauxval_polyfill(unsigned long type) {
+	ElfW(auxv_t) *p;
+
+	for (p = g_auxv; p->a_type != AT_NULL; p++) {
+		if (p->a_type == type) {
+			return p->a_un.a_val;
+		}
+	}
+
+	errno = ENOENT;
+	return 0;
 }
 
-static int _getauxval_init(){
+static bool _getauxval_read(int *errsv) {
+	int fd;
+
+	if ((fd = open("/proc/self/auxv", O_RDONLY)) == -1) {
+		if (errsv != NULL) {
+			*errsv = errno;
+		}
+
+		return false;
+	}
+
 	ElfW(auxv_t) pairs[256];
-	
-	int fd = open ("/proc/self/auxv", O_RDONLY);
-	if(fd < 0) return -1;
+	ssize_t rlen;
 
-	ssize_t rlen = read (fd, pairs, sizeof(pairs));
-	close (fd);
-  	if (rlen < 0) return -1;
+	if ((rlen = read(fd, pairs, sizeof(pairs))) == -1) {
+		if (errsv != NULL) {
+			*errsv = errno;
+		}
 
-	size_t n = (size_t)rlen / sizeof(pairs[0]);
+		close(fd);
+		return false;
+	}
+
+	close(fd);
 
 	DBG_EXPR({
-		for(int i=0; i<n; i++){
+		size_t n = (size_t)rlen / sizeof(pairs[0]);
+
+		for (unsigned int i = 0; i < n; i++) {
 			DBG("getauxval", "0x%x -> 0x%x\n", pairs[i].a_type, pairs[i].a_un.a_val);
 		}
 	});
 
-	g_auxv = malloc(rlen);
+	if ((g_auxv = malloc(rlen)) == NULL) {
+		if (errsv != NULL) {
+			*errsv = errno;
+		}
+
+		return false;
+	}
+
 	memcpy(g_auxv, pairs, rlen);
-	return 0;
+
+	return true;
 }
 
 
-static void
-__attribute__((constructor))
-getauxval_init(){
+static unsigned long _getauxval_init_wrapper(unsigned long type) {
 	DBG("getauxval", "init\n");
 
-#ifndef SKIP_GLIBC
-	void *glibc_getauxval = dlsym(RTLD_NEXT, "getauxval");
-	if(glibc_getauxval != NULL){
-		getauxval_fn = glibc_getauxval;
-	} else
-#endif
-	{
-		if(_getauxval_init() < 0){
-			fputs("getauxval_init() failed\n", stderr);
+	bool skip_glibc = getauxval_default_skip_glibc;
+	const char *env;
+
+	if ((env = getenv("GLIBC_POLYFILLS_GETAUXVAL_SKIP_GLIBC")) != NULL) {
+		skip_glibc = (env[0] == '1');
+
+		DBG("getauxval", "skip_glibc: default=%d, env=%d\n", getauxval_default_skip_glibc, skip_glibc);
+	}
+
+	pfn_getauxval fptr = NULL;
+
+	if (!skip_glibc) {
+		fptr = dlsym(RTLD_NEXT, "getauxval");
+	}
+
+	if (fptr == NULL) {
+		/* either glibc wasn't searched or getauxval wasn't found */
+		int errsv = 0;
+
+		if (!_getauxval_read(&errsv)) {
+			fprintf(stderr, "_getauxval_read() failed: %s\n", strerror(errsv));
 			abort();
 		}
-		getauxval_fn = &_getauxval;
+
+		fptr = &_getauxval_polyfill;
 	}
+
+	getauxval_fn = fptr;
+
+	return getauxval_fn(type);
 }
 
-static void __attribute__((destructor))
-getauxval_deinit(){
-	if(g_auxv != NULL){
+static __attribute__((destructor)) void _getauxval_dtor(void) {
+	if (g_auxv != NULL) {
 		free(g_auxv);
 		g_auxv = NULL;
 	}
 }
 
-
-unsigned long getauxval(unsigned long type){
+unsigned long getauxval(unsigned long type) {
 	return getauxval_fn(type);
 }

--- a/src/common.h
+++ b/src/common.h
@@ -9,9 +9,9 @@
 
 extern bool _glibc_polyfills_debug;
 
-#define LOG(fmt, ...) do{ \
-    if(_glibc_polyfills_debug) fprintf(stderr, fmt, ##__VA_ARGS__); \
-} while(0)
+#define LOG(fmt, ...) ({ \
+    if (_glibc_polyfills_debug) fprintf(stderr, fmt, ##__VA_ARGS__); \
+})
 
 #define DBG(module, fmt, ...) LOG("[" module "]: " fmt, ##__VA_ARGS__)
 


### PR DESCRIPTION
Fix crash in Kodi caused by library constructor (in `libcrypto` from OpenSSL) calling `getauxval()` before our constructors had run.